### PR TITLE
feat: SET-315 fix generating uuid requiring admin account

### DIFF
--- a/extension/api.go
+++ b/extension/api.go
@@ -158,11 +158,6 @@ func (api *PrivateExtensionAPI) GenerateExtensionApprovalUuid(ctx context.Contex
 		txa.PrivateFor = append(txa.PrivateFor, participants...)
 	}
 
-	txArgs, err := api.privacyService.GenerateTransactOptions(txa)
-	if err != nil {
-		return "", err
-	}
-
 	psiManagementContractClient := api.privacyService.managementContract(psi)
 	defer psiManagementContractClient.Close()
 	voterList, err := psiManagementContractClient.GetAllVoters(addressToVoteOn)
@@ -176,7 +171,7 @@ func (api *PrivateExtensionAPI) GenerateExtensionApprovalUuid(ctx context.Contex
 	if api.checkAlreadyVoted(addressToVoteOn, externalSignerAddress, psi) {
 		return "", errors.New("already voted")
 	}
-	uuid, err := generateUuid(addressToVoteOn, txArgs.PrivateFrom, txArgs.PrivateFor, api.privacyService.ptm)
+	uuid, err := generateUuid(addressToVoteOn, txa.PrivateFrom, txa.PrivateFor, api.privacyService.ptm)
 	if err != nil {
 		return "", err
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -1254,7 +1254,7 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'generateExtensionApprovalUuid',
 			call: 'quorumExtension_generateExtensionApprovalUuid',
-			params: 2,
+			params: 3,
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputTransactionFormatter]
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
Generate uuid should not require admin accounts. Also, JSON RPC call to generate approval uuid was failing due to invalid number of parameters