### PR TITLE
fix: memory leak from policy registration (#1660)

### DIFF
--- a/consensus/istanbul/validator/proposerpolicy_test.go
+++ b/consensus/istanbul/validator/proposerpolicy_test.go
@@ -24,15 +24,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProposerPolicy(t *testing.T) {
-	addr1 := common.HexToAddress("0xc53f2189bf6d7bf56722731787127f90d319e112")
-	addr2 := common.HexToAddress("0xed2d479591fe2c5626ce09bca4ed2a62e00e5bc2")
-	addr3 := common.HexToAddress("0xc8417f834995aaeb35f342a67a4961e19cd4735c")
-	addr4 := common.HexToAddress("0x784ae51f5013b51c8360afdf91c6bc5a16f586ea")
-	addr5 := common.HexToAddress("0xecf0974e6f0630fd91ea4da8399cdb3f59e5220f")
-	addr6 := common.HexToAddress("0x411c4d11acd714b82a5242667e36de14b9e1d10b")
+var (
+	addr1    = common.HexToAddress("0xc53f2189bf6d7bf56722731787127f90d319e112")
+	addr2    = common.HexToAddress("0xed2d479591fe2c5626ce09bca4ed2a62e00e5bc2")
+	addr3    = common.HexToAddress("0xc8417f834995aaeb35f342a67a4961e19cd4735c")
+	addr4    = common.HexToAddress("0x784ae51f5013b51c8360afdf91c6bc5a16f586ea")
+	addr5    = common.HexToAddress("0xecf0974e6f0630fd91ea4da8399cdb3f59e5220f")
+	addr6    = common.HexToAddress("0x411c4d11acd714b82a5242667e36de14b9e1d10b")
+	addr7    = common.HexToAddress("0x681381b3D0DaaC179d95aCc9e22E23da2DA670f6")
+	addrSet  = []common.Address{addr1, addr2, addr3, addr4, addr5, addr6}
+	addrSet2 = []common.Address{addr7, addr1, addr2, addr3, addr4, addr5}
+)
 
-	addrSet := []common.Address{addr1, addr2, addr3, addr4, addr5, addr6}
+func TestProposerPolicy(t *testing.T) {
 	addressSortedByByte := []common.Address{addr6, addr4, addr1, addr3, addr5, addr2}
 	addressSortedByString := []common.Address{addr6, addr4, addr1, addr2, addr5, addr3}
 
@@ -50,4 +54,18 @@ func TestProposerPolicy(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		assert.Equal(t, addressSortedByString[i].Hex(), valList[i].String(), "validatorSet not string sorted")
 	}
+}
+
+func TestProposerPolicyRegistration(t *testing.T) {
+	// test that registration can't go beyond MaxValidatorSetInRegistry limit
+	pp := istanbul.NewRoundRobinProposerPolicy()
+	pp2 := istanbul.NewRoundRobinProposerPolicy()
+	valSet := NewSet(addrSet, pp)
+	valSet2 := NewSet(addrSet2, pp2)
+
+	for i := 0; i < istanbul.MaxValidatorSetInRegistry+100; i++ {
+		pp.RegisterValidatorSet(valSet)
+	}
+	pp.RegisterValidatorSet(valSet2)
+	assert.Equal(t, istanbul.MaxValidatorSetInRegistry, pp.GetRegistrySize(), "validator set not dropped")
 }


### PR DESCRIPTION
There is a memory leak when registering validators to a proposal policy registry. See https://github.com/Consensys/quorum/pull/1687.

This hotfix is created to address the memory leak. Evidence documented in https://partior.atlassian.net/browse/SET-389