### PR TITLE
Add update transitions cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GoQuorum is a fork of [go-ethereum](https://github.com/ethereum/go-ethereum) and
 
 Key enhancements over go-ethereum:
 
-* [__Privacy__](https://consensys.net/docs/goquorum//en/latest/concepts/privacy/privacy/) - GoQuorum supports private transactions and private contracts through public/private state separation, and utilises peer-to-peer encrypted message exchanges (see [Tessera](https://github.com/consensys/tessera)) for directed transfer of private data to network participants
+* [__Privacy__](https://consensys.net/docs/goquorum//en/latest/concepts/privacy/) - GoQuorum supports private transactions and private contracts through public/private state separation, and utilises peer-to-peer encrypted message exchanges (see [Tessera](https://github.com/consensys/tessera)) for directed transfer of private data to network participants
 * [__Alternative Consensus Mechanisms__](https://consensys.net/docs/goquorum//en/latest/concepts/consensus/overview/) - with no need for POW/POS in a permissioned network, GoQuorum instead offers multiple consensus mechanisms that are more appropriate for consortium chains:
     * [__QBFT__](https://consensys.net/docs/goquorum/en/latest/configure-and-manage/configure/consensus-protocols/qbft/) - Improved version of IBFT that is interoperable with Hyperledger Besu
     * [__Istanbul BFT__](https://consensys.net/docs/goquorum/en/latest/configure-and-manage/configure/consensus-protocols/ibft/) - a PBFT-inspired consensus algorithm with transaction finality, by AMIS.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following GoQuorum-related libraries/applications have been created by Third
 * [ERC20 REST service](https://github.com/web3labs/erc20-rest-service) - a GoQuorum-supported RESTful service for creating and managing ERC-20 tokens
 * [Nethereum Quorum](https://github.com/Nethereum/Nethereum/tree/master/src/Nethereum.Quorum) - a .NET GoQuorum adapter
 * [web3j-quorum](https://github.com/web3j/web3j-quorum) - an extension to the web3j Java library providing support for the GoQuorum API
-* [Apache Camel](http://github.com/apache/camel) - an Apache Camel component providing support for the GoQuorum API using web3j library. Here is the artcile describing how to use Apache Camel with Ethereum and GoQuorum https://medium.com/@bibryam/enterprise-integration-for-ethereum-fa67a1577d43
+* [Apache Camel](http://github.com/apache/camel) - an Apache Camel component providing support for the GoQuorum API using web3j library. Here is the article describing how to use Apache Camel with Ethereum and GoQuorum https://medium.com/@bibryam/enterprise-integration-for-ethereum-fa67a1577d43
 
 ## Contributing
 GoQuorum is built on open source and we invite you to contribute enhancements. Upon review you will be required to complete a Contributor License Agreement (CLA) before we are able to merge. If you have any questions about the contribution process, please feel free to send an email to [info@goquorum.com](mailto:info@goquorum.com). Please see the [Contributors guide](.github/CONTRIBUTING.md) for more information about the process.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -269,6 +269,7 @@ func init() {
 	app.Commands = []cli.Command{
 		// See chaincmd.go:
 		initCommand,
+		updateCommand,
 		mpsdbUpgradeCommand,
 		importCommand,
 		exportCommand,

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -132,7 +132,7 @@ func (context *chainContext) CheckAndSetPrivateState(txLogs []*types.Log, privat
 
 // End Quorum
 
-// chainContext construts the context reader which is used by the evm for reading
+// chainContext constructs the context reader which is used by the evm for reading
 // the necessary chain context.
 func (api *API) chainContext(ctx context.Context) core.ChainContext {
 	return &chainContext{api: api, ctx: ctx}
@@ -226,13 +226,13 @@ type blockTraceTask struct {
 	statedb *state.StateDB   // Intermediate state prepped for tracing
 	block   *types.Block     // Block to trace the transactions from
 	rootref common.Hash      // Trie root reference held for this task
-	results []*txTraceResult // Trace results procudes by the task
+	results []*txTraceResult // Trace results produced by the task
 	// Quorum
 	privateStateDb   *state.StateDB
 	privateStateRepo mps.PrivateStateRepository
 }
 
-// blockTraceResult represets the results of tracing a single block when an entire
+// blockTraceResult represents the results of tracing a single block when an entire
 // chain is being traced.
 type blockTraceResult struct {
 	Block  hexutil.Uint64   `json:"block"`  // Block number corresponding to this trace
@@ -730,7 +730,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		}
 	}
 	for i, tx := range block.Transactions() {
-		// Prepare the trasaction for un-traced execution
+		// Prepare the transaction for un-traced execution
 		var (
 			msg, _    = tx.AsMessage(signer)
 			txContext = core.NewEVMTxContext(msg)
@@ -955,7 +955,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *txTrac
 				return nil, err
 			}
 		}
-		// Constuct the JavaScript tracer to execute with
+		// Construct the JavaScript tracer to execute with
 		if tracer, err = New(*config.Tracer, txContext); err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 	google.golang.org/grpc v1.46.0
+	google.golang.org/protobuf v1.28.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce


### PR DESCRIPTION
Transitions for IBFT and QBFT are configurations stored under genesis block. Genesis block are written when geth init is called. There are many instances when new transitions are introduced which does not require an entire rewrite of the rest of the chain configuration, nor the genesis block.

This PR introduces an additional helper method, geth update to allow for the selective updates of only transitions to be written down to chain configuration. This reduces the number of configurations which might be unintentionally updated when calling geth init, and also makes it clearer to the user on how to add transitions to an existing network.