### PR TITLE
feat: SET-460 Add logging for validator set

### DIFF
--- a/consensus/istanbul/ibft/engine/engine.go
+++ b/consensus/istanbul/ibft/engine/engine.go
@@ -332,7 +332,7 @@ func (e *Engine) Seal(chain consensus.ChainHeaderReader, block *types.Block, val
 	number := header.Number.Uint64()
 
 	if _, v := validators.GetByAddress(e.signer); v == nil {
-		log.Warn("Engine signer (sealing) is not part of validator set", "signer", e.signer, "validators", fmt.Sprintf("%v", validators.List()))
+		log.Debug("Engine signer (sealing) is not part of validator set", "signer", e.signer, "validators", fmt.Sprintf("%v", validators.List()))
 
 		return block, istanbulcommon.ErrUnauthorized
 	}

--- a/consensus/istanbul/ibft/engine/engine.go
+++ b/consensus/istanbul/ibft/engine/engine.go
@@ -2,6 +2,7 @@ package ibftengine
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -14,8 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
@@ -331,11 +332,7 @@ func (e *Engine) Seal(chain consensus.ChainHeaderReader, block *types.Block, val
 	number := header.Number.Uint64()
 
 	if _, v := validators.GetByAddress(e.signer); v == nil {
-		addresses := make([]string, len(validators.List()))
-		for i, validator := range validators.List() {
-			addresses[i] = validator.Address().String()
-		}	
-		log.Warn("Engine signer (sealing) is not part of validator set", "signer", e.signer, "validators", validators)
+		log.Warn("Engine signer (sealing) is not part of validator set", "signer", e.signer, "validators", fmt.Sprintf("%v", validators.List()))
 
 		return block, istanbulcommon.ErrUnauthorized
 	}

--- a/consensus/istanbul/ibft/engine/engine.go
+++ b/consensus/istanbul/ibft/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
@@ -330,6 +331,12 @@ func (e *Engine) Seal(chain consensus.ChainHeaderReader, block *types.Block, val
 	number := header.Number.Uint64()
 
 	if _, v := validators.GetByAddress(e.signer); v == nil {
+		addresses := make([]string, len(validators.List()))
+		for i, validator := range validators.List() {
+			addresses[i] = validator.Address().String()
+		}	
+		log.Warn("Engine signer (sealing) is not part of validator set", "signer", e.signer, "validators", validators)
+
 		return block, istanbulcommon.ErrUnauthorized
 	}
 

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -18,6 +18,7 @@ package istanbul
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -67,7 +68,7 @@ func CheckValidatorSignature(valSet ValidatorSet, data []byte, sig []byte) (comm
 	}
 
 	// 3. Log signer that is missing in validator set
-	log.Warn("Signer is missing from validator set", "signer", signer, "valSet", fmt.Sprintf("%v", valSet.List()))
+	log.Debug("Signer is missing from validator set", "signer", signer, "valSet", fmt.Sprintf("%v", valSet.List()))
 
 	return common.Address{}, ErrUnauthorizedAddress
 }

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -17,6 +17,7 @@
 package istanbul
 
 import (
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -66,11 +67,7 @@ func CheckValidatorSignature(valSet ValidatorSet, data []byte, sig []byte) (comm
 	}
 
 	// 3. Log signer that is missing in validator set
-	addresses := make([]string, len(valSet.List()))
-	for i, validator := range valSet.List() {
-		addresses[i] = validator.Address().String()
-	}	
-	log.Warn("Signer is missing from validator set", "signer", signer, "validatorSet", addresses)
+	log.Warn("Signer is missing from validator set", "signer", signer, "valSet", fmt.Sprintf("%v", valSet.List()))
 
 	return common.Address{}, ErrUnauthorizedAddress
 }

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -65,5 +65,12 @@ func CheckValidatorSignature(valSet ValidatorSet, data []byte, sig []byte) (comm
 		return val.Address(), nil
 	}
 
+	// 3. Log signer that is missing in validator set
+	addresses := make([]string, len(valSet.List()))
+	for i, validator := range valSet.List() {
+		addresses[i] = validator.Address().String()
+	}	
+	log.Warn("Signer is missing from validator set", "signer", signer, "validatorSet", addresses)
+
 	return common.Address{}, ErrUnauthorizedAddress
 }


### PR DESCRIPTION
https://partior.atlassian.net/browse/SET-460

TLDR:
- Node is logging error: `Failed to decode message from payload` -> Istanbul message sender is not part of the validator set 

This PR introduces logging to check:
- Who is in the validator set when the error is printed out?
- Who is sending the message