### PR TITLE
metrics: SET-512 add summary sum to metrics

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -61,12 +61,12 @@ func (c *collector) addGaugeFloat64(name string, m metrics.GaugeFloat64) {
 func (c *collector) addHistogram(name string, m metrics.Histogram) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
-	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
-	c.buff.WriteRune('\n')
+	c.writeSummaryCounter(name, m.Count())
+	c.writeSummarySum(name, m.Sum())
 }
 
 func (c *collector) addMeter(name string, m metrics.Meter) {
@@ -76,12 +76,12 @@ func (c *collector) addMeter(name string, m metrics.Meter) {
 func (c *collector) addTimer(name string, m metrics.Timer) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
-	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
-	c.buff.WriteRune('\n')
+	c.writeSummaryCounter(name, m.Count())
+	c.writeSummarySum(name, m.Sum())
 }
 
 func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
@@ -90,12 +90,12 @@ func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
 	}
 	ps := m.Percentiles([]float64{50, 95, 99})
 	val := m.Values()
-	c.writeSummaryCounter(name, len(val))
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	c.writeSummaryPercentile(name, "0.50", ps[0])
 	c.writeSummaryPercentile(name, "0.95", ps[1])
 	c.writeSummaryPercentile(name, "0.99", ps[2])
-	c.buff.WriteRune('\n')
+	c.writeSummaryCounter(name, len(val))
+	c.writeSummarySum(name, 0)
 }
 
 func (c *collector) writeGaugeCounter(name string, value interface{}) {
@@ -106,7 +106,11 @@ func (c *collector) writeGaugeCounter(name string, value interface{}) {
 
 func (c *collector) writeSummaryCounter(name string, value interface{}) {
 	name = mutateKey(name + "_count")
-	c.buff.WriteString(fmt.Sprintf(typeCounterTpl, name))
+	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
+}
+
+func (c *collector) writeSummarySum(name string, value interface{}) {
+	name = mutateKey(name + "_sum")
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
 }
 

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -67,9 +67,6 @@ test_gauge 23456
 # TYPE test_gauge_float64 gauge
 test_gauge_float64 34567.89
 
-# TYPE test_histogram_count counter
-test_histogram_count 0
-
 # TYPE test_histogram summary
 test_histogram {quantile="0.5"} 0
 test_histogram {quantile="0.75"} 0
@@ -77,12 +74,12 @@ test_histogram {quantile="0.95"} 0
 test_histogram {quantile="0.99"} 0
 test_histogram {quantile="0.999"} 0
 test_histogram {quantile="0.9999"} 0
+test_histogram_count 0
+
+test_histogram_sum 0
 
 # TYPE test_meter gauge
 test_meter 9999999
-
-# TYPE test_timer_count counter
-test_timer_count 6
 
 # TYPE test_timer summary
 test_timer {quantile="0.5"} 2.25e+07
@@ -91,14 +88,17 @@ test_timer {quantile="0.95"} 1.2e+08
 test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
+test_timer_count 6
 
-# TYPE test_resetting_timer_count counter
-test_resetting_timer_count 6
+test_timer_sum 230000000
 
 # TYPE test_resetting_timer summary
 test_resetting_timer {quantile="0.50"} 12000000
 test_resetting_timer {quantile="0.95"} 120000000
 test_resetting_timer {quantile="0.99"} 120000000
+test_resetting_timer_count 6
+
+test_resetting_timer_sum 0
 
 `
 	exp := c.buff.String()

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -75,7 +75,6 @@ test_histogram {quantile="0.99"} 0
 test_histogram {quantile="0.999"} 0
 test_histogram {quantile="0.9999"} 0
 test_histogram_count 0
-
 test_histogram_sum 0
 
 # TYPE test_meter gauge
@@ -89,15 +88,13 @@ test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
 test_timer_count 6
-
-test_timer_sum 230000000
+test_timer_sum 0
 
 # TYPE test_resetting_timer summary
 test_resetting_timer {quantile="0.50"} 12000000
 test_resetting_timer {quantile="0.95"} 120000000
 test_resetting_timer {quantile="0.99"} 120000000
 test_resetting_timer_count 6
-
 test_resetting_timer_sum 0
 
 `


### PR DESCRIPTION
Cherry-pick from 23.4.0 to 24.4.1

This PR is required to generate metrics that can be ingested to splunk otel collector

[Specs](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/)
- The quantile label on non-suffixed metrics is used to identify quantile points in summary metrics. Each Prometheus line produces one quantile on the resulting summary.
- Lines with _count and _sum suffixes are used to determine the summary’s count and sum.
- If _count is not present, the metric MUST be dropped.
- If _sum is not present, the summary’s sum MUST be set to zero.