### PR TITLE
feat: SET-521 backport maxrequesttimeout to IBFT

### DIFF
--- a/consensus/istanbul/ibft/core/core.go
+++ b/consensus/istanbul/ibft/core/core.go
@@ -332,11 +332,37 @@ func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
 	// set timeout based on the round number
-	timeout := time.Duration(c.config.GetConfig(c.current.Sequence()).RequestTimeout) * time.Millisecond
+	baseTimeout := time.Duration(c.config.GetConfig(c.current.Sequence()).RequestTimeout) * time.Millisecond
 	round := c.current.Round().Uint64()
-	if round > 0 {
-		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
+	maxRequestTimeout := time.Duration(c.config.GetConfig(c.current.Sequence()).MaxRequestTimeoutSeconds) * time.Second
+
+	// If the upper limit of the request timeout is capped by small maxRequestTimeout, round can be a quite large number,
+	// which leads to float64 overflow, making its value negative or zero forever after some point.
+	// In this case we cannot simply use math.Pow and have to implement a safeguard on our own, at the cost of performance (which is not important in this case).
+	var timeout time.Duration
+	if maxRequestTimeout > time.Duration(0) {
+		timeout = baseTimeout
+		for i := uint64(0); i < round; i++ {
+			timeout = timeout * 2
+			if timeout > maxRequestTimeout {
+				timeout = maxRequestTimeout
+				break
+			}
+		}
+		// prevent log storm when unexpected overflow happens
+		if timeout < baseTimeout {
+			c.currentLogger(true).Error("IBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
+				"timeout", timeout.Seconds(),
+				"max_request_timeout", maxRequestTimeout.Seconds(),
+			)
+			timeout = maxRequestTimeout
+		}
+	} else {
+		// effectively impossible to observe overflow happen when maxRequestTimeout is disabled
+		timeout = baseTimeout * time.Duration(math.Pow(2, float64(round)))
 	}
+
+	c.currentLogger(true).Trace("IBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
 		c.sendEvent(timeoutEvent{})
 	})

--- a/consensus/istanbul/ibft/core/handler.go
+++ b/consensus/istanbul/ibft/core/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	istanbulcommon "github.com/ethereum/go-ethereum/consensus/istanbul/common"
 	ibfttypes "github.com/ethereum/go-ethereum/consensus/istanbul/ibft/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // Start implements core.Engine.Start
@@ -206,4 +207,20 @@ func (c *core) handleTimeoutMsg() {
 	} else {
 		c.sendNextRoundChange()
 	}
+}
+
+func (c *core) currentLogger(state bool) log.Logger {
+	logCtx := []interface{}{}
+	if c.current != nil {
+		logCtx = append(logCtx,
+			"current.round", c.current.Round().Uint64(),
+			"current.sequence", c.current.Sequence().Uint64(),
+		)
+	}
+
+	if state {
+		logCtx = append(logCtx, "state", c.state)
+	}
+
+	return c.logger.New(logCtx...)
 }


### PR DESCRIPTION
Requesttimeout doubles whenever majority consensus is not reached. The longer the network goes down, the longer it takes for it to recover. There should be a hard cap on the wait for the next round change to prevent having the entire network to do a coordinated restart.