### PR TITLE
feat: SET-542 added RW mutex for StateDB Copy

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -202,7 +202,9 @@ func (s *StateDB) Error() error {
 }
 
 func (s *StateDB) AddLog(log *types.Log) {
+	s.journalMutex.Lock()
 	s.journal.append(addLogChange{txhash: s.thash})
+	s.journalMutex.Unlock()
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -837,7 +839,6 @@ func (s *StateDB) Copy() *StateDB {
 	}
 
 	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 	// Copy the dirty states, logs, and preimages
 	for _, addr := range dirties {
 		// As documented [here](https://github.com/ethereum/go-ethereum/pull/16485#issuecomment-380438527),
@@ -877,6 +878,7 @@ func (s *StateDB) Copy() *StateDB {
 		}
 		state.logs[hash] = cpy
 	}
+	s.mutex.RUnlock()
 	for hash, preimage := range s.preimages {
 		state.preimages[hash] = preimage
 	}


### PR DESCRIPTION
https://partior.atlassian.net/browse/SET-542

Issue:
- Quorum throws a panic (seg fault) during load testing
- During testing, function `Copy()` is called to copy the `stateDb` contents, which includes the `logs` mapping
- However another go routine is modifying the `logs` mapping, which causes a raise condition `fatal error: concurrent map iteration and map write` 
- Quorum mutex locks were introduced in this PR (didn't account for all race conditions) -> https://github.com/Consensys/quorum/pull/1331/files

Proposed solution: 
- Acquire the read mutex for `Copy()` and only release at the end of the function
- Acquire mutex when writing to `logs` mapping, and release it at the end of the `AddLog` function  

Smoke test logs

```
Gradle Test Executor 2 finished executing tests.

> Task :e2e-testing:test
  subtract(Object, Object, String, String)

    Test [1] 623.0, 200.0, USD, 423 PASSED
    Test [2] 200.22, 100.0, SGD, 100.22 PASSED
    Test [3] 500.36, 299.0, JPY, 201 PASSED
    Test [4] 200.36678, 100.0, USD, 100.37 PASSED
    Test [5] 581.36678, 100.0, USD, 481.37 PASSED
    Test [6] 200, 100.367899, USD, 99.63 PASSED
    Test [7] 200, 100.367899, USD, 99.63 PASSED

  add(Object, Object, String, String)

    Test [1] 200.0, 200.0, USD, 400 PASSED
    Test [2] 200.36, 100.0, JPY, 300 PASSED
    Test [3] 200.0, 200.22, SGD, 400.22 PASSED
    Test [4] 200.36, 100.36, JPY, 301 PASSED
    Test [5] 200.0, 100.367899, USD, 300.37 PASSED
    Test [6] 200, 100.367899, USD, 300.37 PASSED
    Test [7] 200, 100.367899, USD, 300.37 PASSED

  multiply(Object, Object, String, String)

    Test [1] 623.0, 200.0, USD, 124600 PASSED
    Test [2] 200.22, 100.0, SGD, 20022 PASSED
    Test [3] 500.36, 299.0, JPY, 149608 PASSED
    Test [4] 200.36678, 100.0, USD, 20036.68 PASSED
    Test [5] 581.36678, 100.0, USD, 58136.68 PASSED
    Test [6] 200, 100.367899, USD, 20073.58 PASSED
    Test [7] 200.11, 3, USD, 600.33 PASSED
    Test [8] 200, 100.367899, USD, 20073.58 PASSED

com.partior.e2e.utils.ReleaseVersionUtilsTest

  isSameOrOlderVersion(String, String, String, boolean)

    Test [1] v23_1_1, , v23_1_0, false PASSED
    Test [2] v24_1_1, , v24_1_0, false PASSED
    Test [3] v23_1_0!, , v24_1_0, false PASSED
    Test [4] v23, , v23_1_0, true PASSED
    Test [5] v23_1_0, , v24_1, true PASSED
    Test [6] v23_1_0, , v24_1_0, true PASSED
    Test [7] v24_1_0, , v24_1_0, true PASSED
    Test [8] v23_1_0, , v23_1_1, true PASSED
    Test [9] v23_1, , v23_1_0, true PASSED
    Test [10] v23_1_0!, , v23_1_0, true PASSED
    Test [11] v23_1_1, v23_1_1, v23_1_0, false PASSED
    Test [12] v24_1_1, v24_1_1, v24_1_0, false PASSED
    Test [13] v23_1_0, v24_2, v24_1, true PASSED
    Test [14] v23_1_0, v24_2_0, v24_1_0, true PASSED
    Test [15] v24_1_0, v24_1_0, v24_1_0, true PASSED
    Test [16] v23_1_0, v24_1_0, v24_2_0, false PASSED

  isSameOrOlderVersionForInvalidVersions(String, String, String, String)

    Test [1] , , v24_1_0, Empty tagReleaseVersion provided PASSED
    Test [2] v24_1_0, , , Empty platformReleaseVersion provided PASSED
    Test [3] , , , Empty tagReleaseVersion provided PASSED
    Test [4] v23_1_0, , null, Empty platformReleaseVersion provided PASSED
    Test [5] null, , v23_1_0, Empty tagReleaseVersion provided PASSED
    Test [6] null, , null, Empty tagReleaseVersion provided PASSED
    Test [7] 23, , v23_1_0, Invalid tagReleaseVersion provided: 23 PASSED
    Test [8] v23_1_0, , v23.1.0, Invalid platformReleaseVersion provided: v23.1.0 PASSED
    Test [9] v23_1_0, v24.0.0, v23_1_0, Invalid tagEndReleaseVersion provided: v24.0.0 PASSED

SUCCESS: Executed 57 tests in 3m 30s

Finished generating test XML results (0.165 secs) into: /home/user/Work/goquorum-unified-k8s/upstream/repo-its/apps-test-gorn/e2e-testing/build/test-results/test
Test report disabled, omitting generation of the HTML test report.
Resolve mutations for :e2e-testing:check (Thread[Execution worker Thread 3,5,main]) started.
:e2e-testing:check (Thread[Execution worker Thread 3,5,main]) started.

> Task :e2e-testing:check
Skipping task ':e2e-testing:check' as it has no actions.
Resolve mutations for :e2e-testing:build (Thread[Execution worker Thread 3,5,main]) started.
:e2e-testing:build (Thread[Execution worker Thread 3,5,main]) started.

> Task :e2e-testing:build
Skipping task ':e2e-testing:build' as it has no actions.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 4m 12s
11 actionable tasks: 11 executed
Some of the file system contents retained in the virtual file system are on file systems that Gradle doesn't support watching. The relevant state was discarded to ensure changes to these locations are properly detected. You can override this by explicitly enabling file system watching.
Stopped 1 worker daemon(s).
```