### PR TITLE
feat: SET-542 add missing read / write mutex locks

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -247,6 +247,9 @@ func (ch refundChange) dirtied() *common.Address {
 }
 
 func (ch addLogChange) revert(s *StateDB) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	
 	logs := s.logs[ch.txhash]
 	if len(logs) == 1 {
 		delete(s.logs, ch.txhash)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -350,11 +350,11 @@ func (s *StateDB) Reset(root common.Hash) error {
 	s.stateObjectsPending = make(map[common.Address]struct{})
 	s.stateObjectsDirty = make(map[common.Address]struct{})
 	s.logs = make(map[common.Hash][]*types.Log)
+	s.logSize = 0
 	s.mutex.Unlock()
 	s.thash = common.Hash{}
 	s.bhash = common.Hash{}
 	s.txIndex = 0
-	s.logSize = 0
 	s.preimages = make(map[common.Hash][]byte)
 	s.clearJournalAndRefund()
 


### PR DESCRIPTION
- Added mutex locks to safeguard `reset()` & reading 

Passed `make test` in quorum